### PR TITLE
Fix bug in gemspec that broke LS 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
 cache: bundler
+jdk:
+  - oraclejdk8
 rvm:
   - jruby-1.7.24
 script: bundle exec rspec spec && bundle exec rspec spec --tag integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.0.18
+  - Fix bug in 0.0.17 that prevented this from working with LS 5.x
 # 0.0.17
   - Expand logstash-core-api constraints to allow for 5.2 functionality
 # 0.0.16

--- a/logstash-codec-nmap.gemspec
+++ b/logstash-codec-nmap.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-nmap'
-  s.version         = '0.0.17'
+  s.version         = '0.0.18'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec may be used to decode Nmap XML"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "codec" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'ruby-nmap', "~> 0.8.0"
 
   s.add_development_dependency 'logstash-devutils'

--- a/spec/codecs/nmap_spec.rb
+++ b/spec/codecs/nmap_spec.rb
@@ -28,7 +28,7 @@ describe LogStash::Codecs::Nmap do
         end
       end
 
-      let(:ids) { subject.map {|e| e["id"] } }
+      let(:ids) { subject.map {|e| e.get("id") } }
       it "should add a unique id field to all events" do
         expect(ids).to eql(ids.uniq)
       end


### PR DESCRIPTION
This substitutes a `~>` for a `=>` in the gemspec so this works right in LS 5.x.