### PR TITLE
Added missing port.service.version info

### DIFF
--- a/lib/logstash/codecs/nmap.rb
+++ b/lib/logstash/codecs/nmap.rb
@@ -213,6 +213,7 @@ class LogStash::Codecs::Nmap < LogStash::Codecs::Base
       'ssl' => service.ssl?,
       'protocol' => protocol,
       'product' => service.product,
+      'version' => service.version,
       'hostname' => service.hostname, # This is just a string
       'device_type' => service.device_type,
       'fingerprint_method' => service.fingerprint_method.to_s,


### PR DESCRIPTION
Added Logstash parsing of the port.service.version information. 

Fixes #24, verified to work on own Logstash

